### PR TITLE
Add support for new generator-ui5-project

### DIFF
--- a/generators/index.js
+++ b/generators/index.js
@@ -92,6 +92,15 @@ module.exports = class extends Generator {
       args.push("--ts")
     }
 
+    // if executed as a sub-sub-generator within $> yo easy-ui5 project,
+    // which uses npm workspaces, we need to adjust the destination path for first uimodule accordingly
+    const crossGeneratorConfig = this.readDestinationJSON(".yo-rc.json")
+    if (crossGeneratorConfig["generator-ui5-project"]) {
+      const uimodules = crossGeneratorConfig["generator-ui5-project"]["uimodules"]
+      const uimodule = uimodules[uimodules.length - 1]
+      this.destinationRoot(this.destinationPath(uimodule))
+    }
+
     this.spawnCommandSync(cmd, args, {
       cwd: this.destinationPath()
     })

--- a/generators/index.js
+++ b/generators/index.js
@@ -86,12 +86,6 @@ module.exports = class extends Generator {
       args.push(specs)
     }
 
-    // if executed as a sub-sub-generator within $> yo easy-ui5 ts-app, we need a means to determine whether we're in TS-land
-    // checking for and existing tsconfig.json in the generated UI5 app is a good indicator for that
-    if (this.options?.ts === true || this.fs.exists(this.destinationPath("tsconfig.json"))) {
-      args.push("--ts")
-    }
-
     // if executed as a sub-sub-generator within $> yo easy-ui5 project,
     // which uses npm workspaces, we need to adjust the destination path for latest uimodule accordingly
     const crossGeneratorConfig = this.readDestinationJSON(".yo-rc.json")
@@ -102,6 +96,13 @@ module.exports = class extends Generator {
         uimodule = uimodules[uimodules.length - 1]
       }
       this.destinationRoot(this.destinationPath(uimodule))
+    }
+
+
+    // if executed as a sub-sub-generator within $> yo easy-ui5 ts-app, we need a means to determine whether we're in TS-land
+    // checking for and existing tsconfig.json in the generated UI5 app is a good indicator for that
+    if (this.options?.ts === true || this.fs.exists(this.destinationPath("tsconfig.json"))) {
+      args.push("--ts")
     }
 
     this.spawnCommandSync(cmd, args, {

--- a/generators/index.js
+++ b/generators/index.js
@@ -93,7 +93,7 @@ module.exports = class extends Generator {
     }
 
     // if executed as a sub-sub-generator within $> yo easy-ui5 project,
-    // which uses npm workspaces, we need to adjust the destination path for first uimodule accordingly
+    // which uses npm workspaces, we need to adjust the destination path for latest uimodule accordingly
     const crossGeneratorConfig = this.readDestinationJSON(".yo-rc.json")
     if (crossGeneratorConfig["generator-ui5-project"]) {
       const uimodules = crossGeneratorConfig["generator-ui5-project"]["uimodules"]

--- a/generators/index.js
+++ b/generators/index.js
@@ -94,8 +94,8 @@ module.exports = class extends Generator {
       let uimodule
       if (uimodules) {
         uimodule = uimodules[uimodules.length - 1]
+        this.destinationRoot(this.destinationPath(uimodule))
       }
-      this.destinationRoot(this.destinationPath(uimodule))
     }
 
 

--- a/generators/index.js
+++ b/generators/index.js
@@ -97,7 +97,10 @@ module.exports = class extends Generator {
     const crossGeneratorConfig = this.readDestinationJSON(".yo-rc.json")
     if (crossGeneratorConfig["generator-ui5-project"]) {
       const uimodules = crossGeneratorConfig["generator-ui5-project"]["uimodules"]
-      const uimodule = uimodules[uimodules.length - 1]
+      let uimodule
+      if (uimodules) {
+        uimodule = uimodules[uimodules.length - 1]
+      }
       this.destinationRoot(this.destinationPath(uimodule))
     }
 


### PR DESCRIPTION
This pull request is to prepare this subgenerator for the upcoming new version of the `generator-ui5-project`, which will use npm workspaces to run and manage the dependencies of one or more uimodule. The new `generator-ui5-project:project` will use this subgenerator via the `static nestedGenerators = ["wdi5]` config, when run via `yo easy-ui5 project:project`.

A little bit of background why I opted to modify this subgenerator itself instead of passing  `--configPath` and `--specs` options to it: The way easy-ui5 runs `nestedGenerators` doesn't allow to pass any options to these nested generators - at least I didn't find a way. I tried to write into `this.options` of the easy-ui5 generator from within a subgenerator, but no luck. Happy to get educated on this tho.
Also, I would have loved to read the uimodules (`workspaces`) from the root `package.json` instead of the `.yo-rc.json`, but the `package.json` simply isn't ready when the wdi5 subgenerator gets executed, as the project subgenerator itself is composed with the uimodule subgenerator (`generator-ui5-project:uimodule`), which handles this part of the `package.json`.

